### PR TITLE
Parser accept substrings of command word

### DIFF
--- a/src/main/java/seedu/jimi/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/AddCommand.java
@@ -62,7 +62,7 @@ public class AddCommand extends Command {
     }
     
     @Override
-    public boolean isCommandWord(String commandWord) {
+    public boolean isValidCommandWord(String commandWord) {
         for (int i = 1; i <= COMMAND_WORD.length(); i++) {
             if (commandWord.equals(COMMAND_WORD.substring(0, i))) {
                 return true;

--- a/src/main/java/seedu/jimi/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/AddCommand.java
@@ -70,5 +70,9 @@ public class AddCommand extends Command {
         }
         return false;
     }
-    
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/jimi/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/AddCommand.java
@@ -25,7 +25,11 @@ public class AddCommand extends Command {
     public static final String MESSAGE_DUPLICATE_TASK = "This task already exists in Jimi";
 
     private final ReadOnlyTask toAdd;
-
+    
+    public AddCommand() {
+        toAdd = null;
+    }
+    
     /**
      * Convenience constructor using raw values.
      *
@@ -44,7 +48,7 @@ public class AddCommand extends Command {
                     new DeadlineTask(new Name(name), new DateTime(dateTime), new UniqueTagList(tagSet));
         }
     }
-
+    
     @Override
     public CommandResult execute() {
         assert model != null;
@@ -54,7 +58,17 @@ public class AddCommand extends Command {
         } catch (UniqueTaskList.DuplicateTaskException e) {
             return new CommandResult(MESSAGE_DUPLICATE_TASK);
         }
-
+        
     }
-
+    
+    @Override
+    public boolean isCommandWord(String commandWord) {
+        for (int i = 1; i <= COMMAND_WORD.length(); i++) {
+            if (commandWord.equals(COMMAND_WORD.substring(0, i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
 }

--- a/src/main/java/seedu/jimi/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/ClearCommand.java
@@ -23,4 +23,9 @@ public class ClearCommand extends Command {
     public boolean isValidCommandWord(String commandWord) {
         return commandWord.equals(COMMAND_WORD);
     }
+    
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/jimi/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/ClearCommand.java
@@ -6,17 +6,21 @@ import seedu.jimi.model.TaskBook;
  * Clears the address book.
  */
 public class ClearCommand extends Command {
-
+    
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Jimi has been cleared!";
-
+    
     public ClearCommand() {}
-
-
+    
     @Override
     public CommandResult execute() {
         assert model != null;
         model.resetData(TaskBook.getEmptyTaskBook());
         return new CommandResult(MESSAGE_SUCCESS);
+    }
+    
+    @Override
+    public boolean isCommandWord(String commandWord) {
+        return commandWord.equals(COMMAND_WORD);
     }
 }

--- a/src/main/java/seedu/jimi/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/ClearCommand.java
@@ -20,7 +20,7 @@ public class ClearCommand extends Command {
     }
     
     @Override
-    public boolean isCommandWord(String commandWord) {
+    public boolean isValidCommandWord(String commandWord) {
         return commandWord.equals(COMMAND_WORD);
     }
 }

--- a/src/main/java/seedu/jimi/logic/commands/Command.java
+++ b/src/main/java/seedu/jimi/logic/commands/Command.java
@@ -30,10 +30,16 @@ public abstract class Command {
     
     /**
      * Checks if a given string is a command word of this command.
+     * Critical commands like "Exit" and "Clear" should have the user type the full command word for it to be valid.
      * 
      * @return true if given string is a valid command word of this command.
      */
     public abstract boolean isValidCommandWord(String commandWord);
+    
+    /**
+     * Returns command word corresponding to this command.
+     */
+    public abstract String getCommandWord();
     
     /**
      * Provides any needed dependencies to the command.

--- a/src/main/java/seedu/jimi/logic/commands/Command.java
+++ b/src/main/java/seedu/jimi/logic/commands/Command.java
@@ -27,7 +27,14 @@ public abstract class Command {
      * @return feedback message of the operation result for display
      */
     public abstract CommandResult execute();
-
+    
+    /**
+     * Checks if a given string is a command word of this command.
+     * 
+     * @return true if given string is a valid command word of this command.
+     */
+    public abstract boolean isCommandWord(String commandWord);
+    
     /**
      * Provides any needed dependencies to the command.
      * Commands making use of any of these should override this method to gain
@@ -43,4 +50,5 @@ public abstract class Command {
     protected void indicateAttemptToExecuteIncorrectCommand() {
         EventsCenter.getInstance().post(new IncorrectCommandAttemptedEvent(this));
     }
+
 }

--- a/src/main/java/seedu/jimi/logic/commands/Command.java
+++ b/src/main/java/seedu/jimi/logic/commands/Command.java
@@ -33,7 +33,7 @@ public abstract class Command {
      * 
      * @return true if given string is a valid command word of this command.
      */
-    public abstract boolean isCommandWord(String commandWord);
+    public abstract boolean isValidCommandWord(String commandWord);
     
     /**
      * Provides any needed dependencies to the command.

--- a/src/main/java/seedu/jimi/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/jimi/logic/commands/CommandResult.java
@@ -4,12 +4,12 @@ package seedu.jimi.logic.commands;
  * Represents the result of a command execution.
  */
 public class CommandResult {
-
+    
     public final String feedbackToUser;
-
+    
     public CommandResult(String feedbackToUser) {
         assert feedbackToUser != null;
         this.feedbackToUser = feedbackToUser;
     }
-
+    
 }

--- a/src/main/java/seedu/jimi/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/DeleteCommand.java
@@ -63,4 +63,9 @@ public class DeleteCommand extends Command {
         }
         return false;
     }
+    
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/jimi/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/DeleteCommand.java
@@ -55,7 +55,7 @@ public class DeleteCommand extends Command {
     }
     
     @Override
-    public boolean isCommandWord(String commandWord) {
+    public boolean isValidCommandWord(String commandWord) {
         for (int i = 1; i <= COMMAND_WORD.length(); i++) {
             if (commandWord.equals(COMMAND_WORD.substring(0, i))) {
                 return true;

--- a/src/main/java/seedu/jimi/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/DeleteCommand.java
@@ -24,6 +24,10 @@ public class DeleteCommand extends Command {
 
     public final int targetIndex;
 
+    public DeleteCommand() {
+        targetIndex = 0;
+    }
+    
     public DeleteCommand(int targetIndex) {
         this.targetIndex = targetIndex;
     }
@@ -50,4 +54,13 @@ public class DeleteCommand extends Command {
         return new CommandResult(String.format(MESSAGE_DELETE_TASK_SUCCESS, taskToDelete));
     }
     
+    @Override
+    public boolean isCommandWord(String commandWord) {
+        for (int i = 1; i <= COMMAND_WORD.length(); i++) {
+            if (commandWord.equals(COMMAND_WORD.substring(0, i))) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/seedu/jimi/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/EditCommand.java
@@ -89,4 +89,9 @@ public class EditCommand extends Command {
         }
         return false;
     }
+    
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/jimi/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/EditCommand.java
@@ -81,7 +81,7 @@ public class EditCommand extends Command {
     }
     
     @Override
-    public boolean isCommandWord(String commandWord) {
+    public boolean isValidCommandWord(String commandWord) {
         for (int i = 1; i <= COMMAND_WORD.length(); i++) {
             if (commandWord.equals(COMMAND_WORD.substring(0, i))) {
                 return true;

--- a/src/main/java/seedu/jimi/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/EditCommand.java
@@ -34,6 +34,10 @@ public class EditCommand extends Command {
     private UniqueTagList newTagList;
     private Name newName;
     
+    public EditCommand() {
+        taskIndex = 0;
+    }
+    
     /**
      * Convenience constructor using raw values.
      * //TODO: change to support FloatingTask, DeadlineTask and Events types as well
@@ -56,6 +60,7 @@ public class EditCommand extends Command {
         }
     }
     
+
     @Override
     public CommandResult execute() {
         UnmodifiableObservableList<ReadOnlyTask> lastShownList = model.getFilteredTaskList();
@@ -73,5 +78,15 @@ public class EditCommand extends Command {
         model.editFloatingTask(taskIndex - 1, new FloatingTask(taskToReplace));
         
         return new CommandResult(String.format(MESSAGE_EDIT_TASK_SUCCESS, taskToReplace));
+    }
+    
+    @Override
+    public boolean isCommandWord(String commandWord) {
+        for (int i = 1; i <= COMMAND_WORD.length(); i++) {
+            if (commandWord.equals(COMMAND_WORD.substring(0, i))) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/seedu/jimi/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/ExitCommand.java
@@ -20,4 +20,8 @@ public class ExitCommand extends Command {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT);
     }
 
+    @Override
+    public boolean isCommandWord(String commandWord) {
+        return commandWord.equals(COMMAND_WORD);
+    }
 }

--- a/src/main/java/seedu/jimi/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/ExitCommand.java
@@ -24,4 +24,9 @@ public class ExitCommand extends Command {
     public boolean isValidCommandWord(String commandWord) {
         return commandWord.equals(COMMAND_WORD);
     }
+    
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/jimi/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/ExitCommand.java
@@ -21,7 +21,7 @@ public class ExitCommand extends Command {
     }
 
     @Override
-    public boolean isCommandWord(String commandWord) {
+    public boolean isValidCommandWord(String commandWord) {
         return commandWord.equals(COMMAND_WORD);
     }
 }

--- a/src/main/java/seedu/jimi/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/FindCommand.java
@@ -17,6 +17,10 @@ public class FindCommand extends Command {
 
     private final Set<String> keywords;
 
+    public FindCommand() {
+        keywords = null;
+    }
+    
     public FindCommand(Set<String> keywords) {
         this.keywords = keywords;
     }
@@ -26,5 +30,14 @@ public class FindCommand extends Command {
         model.updateFilteredTaskList(keywords);
         return new CommandResult(getMessageForTaskListShownSummary(model.getFilteredTaskList().size()));
     }
-
+    
+    @Override
+    public boolean isCommandWord(String commandWord) {
+        for (int i = 1; i <= COMMAND_WORD.length(); i++) {
+            if (commandWord.equals(COMMAND_WORD.substring(0, i))) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/seedu/jimi/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/FindCommand.java
@@ -32,7 +32,7 @@ public class FindCommand extends Command {
     }
     
     @Override
-    public boolean isCommandWord(String commandWord) {
+    public boolean isValidCommandWord(String commandWord) {
         for (int i = 1; i <= COMMAND_WORD.length(); i++) {
             if (commandWord.equals(COMMAND_WORD.substring(0, i))) {
                 return true;

--- a/src/main/java/seedu/jimi/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/FindCommand.java
@@ -40,4 +40,9 @@ public class FindCommand extends Command {
         }
         return false;
     }
+    
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/jimi/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/HelpCommand.java
@@ -23,4 +23,14 @@ public class HelpCommand extends Command {
         EventsCenter.getInstance().post(new ShowHelpRequestEvent());
         return new CommandResult(SHOWING_HELP_MESSAGE);
     }
+    
+    @Override
+    public boolean isCommandWord(String commandWord) {
+        for (int i = 1; i <= COMMAND_WORD.length(); i++) {
+            if (commandWord.equals(COMMAND_WORD.substring(0, i))) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/seedu/jimi/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/HelpCommand.java
@@ -33,4 +33,9 @@ public class HelpCommand extends Command {
         }
         return false;
     }
+    
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/jimi/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/HelpCommand.java
@@ -25,7 +25,7 @@ public class HelpCommand extends Command {
     }
     
     @Override
-    public boolean isCommandWord(String commandWord) {
+    public boolean isValidCommandWord(String commandWord) {
         for (int i = 1; i <= COMMAND_WORD.length(); i++) {
             if (commandWord.equals(COMMAND_WORD.substring(0, i))) {
                 return true;

--- a/src/main/java/seedu/jimi/logic/commands/IncorrectCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/IncorrectCommand.java
@@ -21,4 +21,9 @@ public class IncorrectCommand extends Command {
     public boolean isValidCommandWord(String commandWord) {
         return false;
     }
+    
+    @Override
+    public String getCommandWord() {
+        return null;
+    }
 }

--- a/src/main/java/seedu/jimi/logic/commands/IncorrectCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/IncorrectCommand.java
@@ -1,22 +1,24 @@
 package seedu.jimi.logic.commands;
 
-
 /**
  * Represents an incorrect command. Upon execution, produces some feedback to the user.
  */
 public class IncorrectCommand extends Command {
-
+    
     public final String feedbackToUser;
-
-    public IncorrectCommand(String feedbackToUser){
+    
+    public IncorrectCommand(String feedbackToUser) {
         this.feedbackToUser = feedbackToUser;
     }
-
+    
     @Override
     public CommandResult execute() {
         indicateAttemptToExecuteIncorrectCommand();
         return new CommandResult(feedbackToUser);
     }
-
+    
+    @Override
+    public boolean isCommandWord(String commandWord) {
+        return false;
+    }
 }
-

--- a/src/main/java/seedu/jimi/logic/commands/IncorrectCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/IncorrectCommand.java
@@ -18,7 +18,7 @@ public class IncorrectCommand extends Command {
     }
     
     @Override
-    public boolean isCommandWord(String commandWord) {
+    public boolean isValidCommandWord(String commandWord) {
         return false;
     }
 }

--- a/src/main/java/seedu/jimi/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/ListCommand.java
@@ -17,4 +17,14 @@ public class ListCommand extends Command {
         model.updateFilteredListToShowAll();
         return new CommandResult(MESSAGE_SUCCESS);
     }
+    
+    @Override
+    public boolean isCommandWord(String commandWord) {
+        for (int i = 1; i <= COMMAND_WORD.length(); i++) {
+            if (commandWord.equals(COMMAND_WORD.substring(0, i))) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/seedu/jimi/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/ListCommand.java
@@ -27,4 +27,9 @@ public class ListCommand extends Command {
         }
         return false;
     }
+    
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
 }

--- a/src/main/java/seedu/jimi/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/ListCommand.java
@@ -19,7 +19,7 @@ public class ListCommand extends Command {
     }
     
     @Override
-    public boolean isCommandWord(String commandWord) {
+    public boolean isValidCommandWord(String commandWord) {
         for (int i = 1; i <= COMMAND_WORD.length(); i++) {
             if (commandWord.equals(COMMAND_WORD.substring(0, i))) {
                 return true;

--- a/src/main/java/seedu/jimi/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/SelectCommand.java
@@ -46,7 +46,7 @@ public class SelectCommand extends Command {
     }
     
     @Override
-    public boolean isCommandWord(String commandWord) {
+    public boolean isValidCommandWord(String commandWord) {
         for (int i = 1; i <= COMMAND_WORD.length(); i++) {
             if (commandWord.equals(COMMAND_WORD.substring(0, i))) {
                 return true;

--- a/src/main/java/seedu/jimi/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/SelectCommand.java
@@ -11,7 +11,7 @@ import seedu.jimi.model.task.ReadOnlyTask;
  */
 public class SelectCommand extends Command {
 
-    public final int targetIndex;
+    private int targetIndex;
 
     public static final String COMMAND_WORD = "select";
 
@@ -23,7 +23,7 @@ public class SelectCommand extends Command {
     public static final String MESSAGE_SELECT_TASK_SUCCESS = "Selected FloatingTask: %1$s";
     
     public SelectCommand() {
-        targetIndex = 0;
+        this.targetIndex = 0;
     }
     
     public SelectCommand(int targetIndex) {
@@ -53,5 +53,10 @@ public class SelectCommand extends Command {
             }
         }
         return false;
+    }
+    
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
     }
 }

--- a/src/main/java/seedu/jimi/logic/commands/SelectCommand.java
+++ b/src/main/java/seedu/jimi/logic/commands/SelectCommand.java
@@ -21,24 +21,37 @@ public class SelectCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_SELECT_TASK_SUCCESS = "Selected FloatingTask: %1$s";
-
+    
+    public SelectCommand() {
+        targetIndex = 0;
+    }
+    
     public SelectCommand(int targetIndex) {
         this.targetIndex = targetIndex;
     }
-
+    
     @Override
     public CommandResult execute() {
-
+        
         UnmodifiableObservableList<ReadOnlyTask> lastShownList = model.getFilteredTaskList();
-
+        
         if (lastShownList.size() < targetIndex) {
             indicateAttemptToExecuteIncorrectCommand();
             return new CommandResult(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
         }
-
+        
         EventsCenter.getInstance().post(new JumpToListRequestEvent(targetIndex - 1));
         return new CommandResult(String.format(MESSAGE_SELECT_TASK_SUCCESS, targetIndex));
-
+        
     }
-
+    
+    @Override
+    public boolean isCommandWord(String commandWord) {
+        for (int i = 1; i <= COMMAND_WORD.length(); i++) {
+            if (commandWord.equals(COMMAND_WORD.substring(0, i))) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/seedu/jimi/logic/parser/JimiParser.java
+++ b/src/main/java/seedu/jimi/logic/parser/JimiParser.java
@@ -78,7 +78,8 @@ public class JimiParser {
         for (Command command : COMMAND_STUB_LIST) {
             // if validation checks implemented by the respective commands are passed
             if (command.isValidCommandWord(commandWord)) {
-                switch (commandWord) {
+                // identifying which command this is
+                switch (command.getCommandWord()) {
                 case AddCommand.COMMAND_WORD :
                     return prepareAdd(arguments);
                 case EditCommand.COMMAND_WORD :

--- a/src/main/java/seedu/jimi/logic/parser/JimiParser.java
+++ b/src/main/java/seedu/jimi/logic/parser/JimiParser.java
@@ -77,7 +77,7 @@ public class JimiParser {
     private Command prepareCommand(String commandWord, String arguments) {
         for (Command command : COMMAND_STUB_LIST) {
             // if validation checks implemented by the respective commands are passed
-            if (command.isCommandWord(commandWord)) {
+            if (command.isValidCommandWord(commandWord)) {
                 switch (commandWord) {
                 case AddCommand.COMMAND_WORD :
                     return prepareAdd(arguments);

--- a/src/main/java/seedu/jimi/logic/parser/JimiParser.java
+++ b/src/main/java/seedu/jimi/logic/parser/JimiParser.java
@@ -51,36 +51,26 @@ public class JimiParser {
         
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
-        switch (commandWord) {
         
-        case AddCommand.COMMAND_WORD :
+        if (AddCommand.isCommandWord(commandWord)) {
             return prepareAdd(arguments);
-        
-        case EditCommand.COMMAND_WORD :
+        } else if (EditCommand.isCommandWord(commandWord)) {
             return prepareEdit(arguments);
-        
-        case SelectCommand.COMMAND_WORD :
+        } else if (SelectCommand.isCommandWord(commandWord)) {
             return prepareSelect(arguments);
-        
-        case DeleteCommand.COMMAND_WORD :
+        } else if (DeleteCommand.isCommandWord(commandWord)) {
             return prepareDelete(arguments);
-        
-        case ClearCommand.COMMAND_WORD :
+        } else if (ClearCommand.isCommandWord(commandWord)) {
             return new ClearCommand();
-        
-        case FindCommand.COMMAND_WORD :
+        } else if (FindCommand.isCommandWord(commandWord)) {
             return prepareFind(arguments);
-        
-        case ListCommand.COMMAND_WORD :
+        } else if (ListCommand.isCommandWord(commandWord)) {     
             return new ListCommand();
-        
-        case ExitCommand.COMMAND_WORD :
+        } else if (ExitCommand.COMMAND_WORD.equals(commandWord)) {        
             return new ExitCommand();
-        
-        case HelpCommand.COMMAND_WORD :
+        } else if (HelpCommand.isCommandWord(commandWord)) {       
             return new HelpCommand();
-        
-        default :
+        } else {        
             return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
         }
     }

--- a/src/main/java/seedu/jimi/logic/parser/JimiParser.java
+++ b/src/main/java/seedu/jimi/logic/parser/JimiParser.java
@@ -35,6 +35,18 @@ public class JimiParser {
     private static final Pattern DETAILS_ARGS_FORMAT = 
             Pattern.compile("(\"(?<taskDetails>.+)\")( by (?<dateTime>.+))?");
     
+    private static final List<Command> COMMAND_STUB_LIST = Arrays.asList(
+            new AddCommand(),
+            new EditCommand(),
+            new SelectCommand(),
+            new DeleteCommand(),
+            new ClearCommand(),
+            new FindCommand(),
+            new ListCommand(),
+            new ExitCommand(),
+            new HelpCommand()
+    );
+    
     public JimiParser() {}
 
     /**
@@ -52,29 +64,40 @@ public class JimiParser {
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
         
-        if (AddCommand.isCommandWord(commandWord)) {
-            return prepareAdd(arguments);
-        } else if (EditCommand.isCommandWord(commandWord)) {
-            return prepareEdit(arguments);
-        } else if (SelectCommand.isCommandWord(commandWord)) {
-            return prepareSelect(arguments);
-        } else if (DeleteCommand.isCommandWord(commandWord)) {
-            return prepareDelete(arguments);
-        } else if (ClearCommand.isCommandWord(commandWord)) {
-            return new ClearCommand();
-        } else if (FindCommand.isCommandWord(commandWord)) {
-            return prepareFind(arguments);
-        } else if (ListCommand.isCommandWord(commandWord)) {
-            return new ListCommand();
-        } else if (ExitCommand.COMMAND_WORD.equals(commandWord)) {
-            return new ExitCommand();
-        } else if (HelpCommand.isCommandWord(commandWord)) {
-            return new HelpCommand();
-        } else {
-            return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
-        }
+        return prepareCommand(commandWord, arguments);
     }
 
+    /**
+     * Identifies which command to prepare according to raw command word.
+     * 
+     * @param commandWord command word from raw input
+     * @param arguments arguments from raw input
+     * @return correct Command corresponding to the command word if valid, else returns incorrect command.
+     */
+    private Command prepareCommand(String commandWord, String arguments) {
+        for (Command command : COMMAND_STUB_LIST) {
+            // if validation checks implemented by the respective commands are passed
+            if (command.isCommandWord(commandWord)) {
+                switch (commandWord) {
+                case AddCommand.COMMAND_WORD :
+                    return prepareAdd(arguments);
+                case EditCommand.COMMAND_WORD :
+                    return prepareEdit(arguments);
+                case SelectCommand.COMMAND_WORD :
+                    return prepareSelect(arguments);
+                case DeleteCommand.COMMAND_WORD :
+                    return prepareDelete(arguments);
+                case FindCommand.COMMAND_WORD :
+                    return prepareFind(arguments);
+                default : // commands which do not require arguments for instantiation
+                    return command;
+                }
+            }
+        }
+        
+        return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
+    }
+    
     /**
      * Parses arguments in the context of the add task command.
      *

--- a/src/main/java/seedu/jimi/logic/parser/JimiParser.java
+++ b/src/main/java/seedu/jimi/logic/parser/JimiParser.java
@@ -64,13 +64,13 @@ public class JimiParser {
             return new ClearCommand();
         } else if (FindCommand.isCommandWord(commandWord)) {
             return prepareFind(arguments);
-        } else if (ListCommand.isCommandWord(commandWord)) {     
+        } else if (ListCommand.isCommandWord(commandWord)) {
             return new ListCommand();
-        } else if (ExitCommand.COMMAND_WORD.equals(commandWord)) {        
+        } else if (ExitCommand.COMMAND_WORD.equals(commandWord)) {
             return new ExitCommand();
-        } else if (HelpCommand.isCommandWord(commandWord)) {       
+        } else if (HelpCommand.isCommandWord(commandWord)) {
             return new HelpCommand();
-        } else {        
+        } else {
             return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
         }
     }

--- a/src/test/java/seedu/jimi/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/jimi/logic/LogicManagerTest.java
@@ -126,12 +126,36 @@ public class LogicManagerTest {
     public void execute_unknownCommandWord() throws Exception {
         String unknownCommand = "uicfhmowqewca";
         assertCommandBehavior(unknownCommand, MESSAGE_UNKNOWN_COMMAND);
+        
+        /* exit and clear should have the user type the full command word for it to be valid */
+        unknownCommand = "ex";
+        assertCommandBehavior(unknownCommand, MESSAGE_UNKNOWN_COMMAND);
+        unknownCommand = "exi";
+        assertCommandBehavior(unknownCommand, MESSAGE_UNKNOWN_COMMAND);
+        unknownCommand = "c";
+        assertCommandBehavior(unknownCommand, MESSAGE_UNKNOWN_COMMAND);
+        unknownCommand = "cl";
+        assertCommandBehavior(unknownCommand, MESSAGE_UNKNOWN_COMMAND);
+        unknownCommand = "cle";
+        assertCommandBehavior(unknownCommand, MESSAGE_UNKNOWN_COMMAND);
+        unknownCommand = "clea";
+        assertCommandBehavior(unknownCommand, MESSAGE_UNKNOWN_COMMAND);
     }
 
     @Test
     public void execute_help() throws Exception {
         assertCommandBehavior("help", HelpCommand.SHOWING_HELP_MESSAGE);
         assertTrue(helpShown);
+        
+        assertCommandBehavior("h", HelpCommand.SHOWING_HELP_MESSAGE);
+        assertTrue(helpShown);
+        
+        assertCommandBehavior("he", HelpCommand.SHOWING_HELP_MESSAGE);
+        assertTrue(helpShown);
+        
+        assertCommandBehavior("hel", HelpCommand.SHOWING_HELP_MESSAGE);
+        assertTrue(helpShown);
+        
     }
 
     @Test
@@ -157,12 +181,24 @@ public class LogicManagerTest {
                 "add \"do dishes\" t/impt t/asd", expectedMessage);
         assertCommandBehavior(
                 "add \"wash //plates\"", expectedMessage);
+        assertCommandBehavior(
+                "a \"do dishes\" t/impt t/asd", expectedMessage);
+        assertCommandBehavior(
+                "a \"wash //plates\"", expectedMessage);
+        assertCommandBehavior(
+                "ad \"do dishes\" t/impt t/asd", expectedMessage);
+        assertCommandBehavior(
+                "ad \"wash //plates\"", expectedMessage);
     }
 
     @Test
     public void execute_add_invalidPersonData() throws Exception {
         assertCommandBehavior(
                 "add \"Valid task\" t/invalid_-[.tag", Tag.MESSAGE_TAG_CONSTRAINTS);
+        assertCommandBehavior(
+                "a \"Valid task\" t/invalid_-[.tag", Tag.MESSAGE_TAG_CONSTRAINTS);
+        assertCommandBehavior(
+                "ad \"Valid task\" t/invalid_-[.tag", Tag.MESSAGE_TAG_CONSTRAINTS);
     }
 
     @Test
@@ -179,6 +215,23 @@ public class LogicManagerTest {
                 expectedAB,
                 expectedAB.getTaskList());
 
+        toBeAdded = helper.laundry();
+        expectedAB.addTask(toBeAdded);
+        
+        assertCommandBehavior(
+                helper.generateAddCommand_A(toBeAdded),
+                String.format(AddCommand.MESSAGE_SUCCESS, toBeAdded),
+                expectedAB,
+                expectedAB.getTaskList());
+        
+        toBeAdded = helper.homework();
+        expectedAB.addTask(toBeAdded);
+        
+        assertCommandBehavior(
+                helper.generateAddCommand_Ad(toBeAdded),
+                String.format(AddCommand.MESSAGE_SUCCESS, toBeAdded),
+                expectedAB,
+                expectedAB.getTaskList());
     }
 
     @Test
@@ -198,6 +251,18 @@ public class LogicManagerTest {
                 AddCommand.MESSAGE_DUPLICATE_TASK,
                 expectedAB,
                 expectedAB.getTaskList());
+        
+        assertCommandBehavior(
+                helper.generateAddCommand_A(toBeAdded),
+                AddCommand.MESSAGE_DUPLICATE_TASK,
+                expectedAB,
+                expectedAB.getTaskList());
+        
+        assertCommandBehavior(
+                helper.generateAddCommand_Ad(toBeAdded),
+                AddCommand.MESSAGE_DUPLICATE_TASK,
+                expectedAB,
+                expectedAB.getTaskList());
 
     }
 
@@ -213,6 +278,18 @@ public class LogicManagerTest {
         helper.addToModel(model, 2);
 
         assertCommandBehavior("list",
+                ListCommand.MESSAGE_SUCCESS,
+                expectedAB,
+                expectedList);
+        assertCommandBehavior("l",
+                ListCommand.MESSAGE_SUCCESS,
+                expectedAB,
+                expectedList);
+        assertCommandBehavior("li",
+                ListCommand.MESSAGE_SUCCESS,
+                expectedAB,
+                expectedList);
+        assertCommandBehavior("lis",
                 ListCommand.MESSAGE_SUCCESS,
                 expectedAB,
                 expectedList);
@@ -255,11 +332,21 @@ public class LogicManagerTest {
     public void execute_selectInvalidArgsFormat_errorMessageShown() throws Exception {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE);
         assertIncorrectIndexFormatBehaviorForCommand("select", expectedMessage);
+        assertIncorrectIndexFormatBehaviorForCommand("s", expectedMessage);
+        assertIncorrectIndexFormatBehaviorForCommand("se", expectedMessage);
+        assertIncorrectIndexFormatBehaviorForCommand("sel", expectedMessage);
+        assertIncorrectIndexFormatBehaviorForCommand("sele", expectedMessage);
+        assertIncorrectIndexFormatBehaviorForCommand("selec", expectedMessage);
     }
 
     @Test
     public void execute_selectIndexNotFound_errorMessageShown() throws Exception {
         assertIndexNotFoundBehaviorForCommand("select");
+        assertIndexNotFoundBehaviorForCommand("s");
+        assertIndexNotFoundBehaviorForCommand("se");
+        assertIndexNotFoundBehaviorForCommand("sel");
+        assertIndexNotFoundBehaviorForCommand("sele");
+        assertIndexNotFoundBehaviorForCommand("selec");
     }
 
     @Test
@@ -276,6 +363,41 @@ public class LogicManagerTest {
                 expectedAB.getTaskList());
         assertEquals(1, targetedJumpIndex);
         assertEquals(model.getFilteredTaskList().get(1), threeFloatingTasks.get(1));
+        
+        assertCommandBehavior("s 1",
+                String.format(SelectCommand.MESSAGE_SELECT_TASK_SUCCESS, 1),
+                expectedAB,
+                expectedAB.getTaskList());
+        assertEquals(0, targetedJumpIndex);
+        assertEquals(model.getFilteredTaskList().get(0), threeFloatingTasks.get(0));
+        
+        assertCommandBehavior("se 2",
+                String.format(SelectCommand.MESSAGE_SELECT_TASK_SUCCESS, 2),
+                expectedAB,
+                expectedAB.getTaskList());
+        assertEquals(1, targetedJumpIndex);
+        assertEquals(model.getFilteredTaskList().get(1), threeFloatingTasks.get(1));
+        
+        assertCommandBehavior("sel 1",
+                String.format(SelectCommand.MESSAGE_SELECT_TASK_SUCCESS, 1),
+                expectedAB,
+                expectedAB.getTaskList());
+        assertEquals(0, targetedJumpIndex);
+        assertEquals(model.getFilteredTaskList().get(0), threeFloatingTasks.get(0));
+        
+        assertCommandBehavior("sele 2",
+                String.format(SelectCommand.MESSAGE_SELECT_TASK_SUCCESS, 2),
+                expectedAB,
+                expectedAB.getTaskList());
+        assertEquals(1, targetedJumpIndex);
+        assertEquals(model.getFilteredTaskList().get(1), threeFloatingTasks.get(1));
+        
+        assertCommandBehavior("selec 1",
+                String.format(SelectCommand.MESSAGE_SELECT_TASK_SUCCESS, 1),
+                expectedAB,
+                expectedAB.getTaskList());
+        assertEquals(0, targetedJumpIndex);
+        assertEquals(model.getFilteredTaskList().get(0), threeFloatingTasks.get(0));
     }
 
 
@@ -283,11 +405,21 @@ public class LogicManagerTest {
     public void execute_deleteInvalidArgsFormat_errorMessageShown() throws Exception {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE);
         assertIncorrectIndexFormatBehaviorForCommand("delete", expectedMessage);
+        assertIncorrectIndexFormatBehaviorForCommand("d", expectedMessage);
+        assertIncorrectIndexFormatBehaviorForCommand("de", expectedMessage);
+        assertIncorrectIndexFormatBehaviorForCommand("del", expectedMessage);
+        assertIncorrectIndexFormatBehaviorForCommand("dele", expectedMessage);
+        assertIncorrectIndexFormatBehaviorForCommand("delet", expectedMessage);
     }
 
     @Test
     public void execute_deleteIndexNotFound_errorMessageShown() throws Exception {
         assertIndexNotFoundBehaviorForCommand("delete");
+        assertIndexNotFoundBehaviorForCommand("d");
+        assertIndexNotFoundBehaviorForCommand("de");
+        assertIndexNotFoundBehaviorForCommand("del");
+        assertIndexNotFoundBehaviorForCommand("dele");
+        assertIndexNotFoundBehaviorForCommand("delet");
     }
 
     @Test
@@ -310,6 +442,9 @@ public class LogicManagerTest {
     public void execute_find_invalidArgsFormat() throws Exception {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE);
         assertCommandBehavior("find ", expectedMessage);
+        assertCommandBehavior("f ", expectedMessage);
+        assertCommandBehavior("fi ", expectedMessage);
+        assertCommandBehavior("fin ", expectedMessage);
     }
 
     @Test
@@ -329,6 +464,21 @@ public class LogicManagerTest {
                 Command.getMessageForTaskListShownSummary(expectedList.size()),
                 expectedAB,
                 expectedList);
+        assertCommandBehavior("fi KEY",
+                Command.getMessageForTaskListShownSummary(expectedList.size()),
+                expectedAB,
+                expectedList);
+
+        assertCommandBehavior("fin KEY",
+                Command.getMessageForTaskListShownSummary(expectedList.size()),
+                expectedAB,
+                expectedList);
+        assertCommandBehavior("f KEY",
+                Command.getMessageForTaskListShownSummary(expectedList.size()),
+                expectedAB,
+                expectedList);
+
+
     }
 
     @Test
@@ -345,6 +495,19 @@ public class LogicManagerTest {
         helper.addToModel(model, fourFloatingTasks);
 
         assertCommandBehavior("find KEY",
+                Command.getMessageForTaskListShownSummary(expectedList.size()),
+                expectedAB,
+                expectedList);
+        assertCommandBehavior("fi KEY",
+                Command.getMessageForTaskListShownSummary(expectedList.size()),
+                expectedAB,
+                expectedList);
+
+        assertCommandBehavior("fin KEY",
+                Command.getMessageForTaskListShownSummary(expectedList.size()),
+                expectedAB,
+                expectedList);
+        assertCommandBehavior("f KEY",
                 Command.getMessageForTaskListShownSummary(expectedList.size()),
                 expectedAB,
                 expectedList);
@@ -367,6 +530,18 @@ public class LogicManagerTest {
                 Command.getMessageForTaskListShownSummary(expectedList.size()),
                 expectedAB,
                 expectedList);
+        assertCommandBehavior("f key rAnDoM",
+                Command.getMessageForTaskListShownSummary(expectedList.size()),
+                expectedAB,
+                expectedList);
+        assertCommandBehavior("fi key rAnDoM",
+                Command.getMessageForTaskListShownSummary(expectedList.size()),
+                expectedAB,
+                expectedList);
+        assertCommandBehavior("fin key rAnDoM",
+                Command.getMessageForTaskListShownSummary(expectedList.size()),
+                expectedAB,
+                expectedList);
     }
 
 
@@ -378,6 +553,20 @@ public class LogicManagerTest {
         FloatingTask adam() throws Exception {
             Name name = new Name("Adam Brown");
             Tag tag1 = new Tag("tag1");
+            UniqueTagList tags = new UniqueTagList(tag1);
+            return new FloatingTask(name, tags);
+        }
+        
+        FloatingTask laundry() throws Exception {
+            Name name = new Name("laundry");
+            Tag tag1 = new Tag("dothem");
+            UniqueTagList tags = new UniqueTagList(tag1);
+            return new FloatingTask(name, tags);
+        }
+        
+        FloatingTask homework() throws Exception {
+            Name name = new Name("homework");
+            Tag tag1 = new Tag("impt");
             UniqueTagList tags = new UniqueTagList(tag1);
             return new FloatingTask(name, tags);
         }
@@ -401,6 +590,36 @@ public class LogicManagerTest {
             StringBuffer cmd = new StringBuffer();
 
             cmd.append("add ");
+            cmd.append("\"");
+            cmd.append(p.getName().toString());
+            cmd.append("\"");
+            UniqueTagList tags = p.getTags();
+            for(Tag t: tags){
+                cmd.append(" t/").append(t.tagName);
+            }
+
+            return cmd.toString();
+        }
+        
+        String generateAddCommand_A(FloatingTask p) {
+            StringBuffer cmd = new StringBuffer();
+
+            cmd.append("a ");
+            cmd.append("\"");
+            cmd.append(p.getName().toString());
+            cmd.append("\"");
+            UniqueTagList tags = p.getTags();
+            for(Tag t: tags){
+                cmd.append(" t/").append(t.tagName);
+            }
+
+            return cmd.toString();
+        }
+        
+        String generateAddCommand_Ad(FloatingTask p) {
+            StringBuffer cmd = new StringBuffer();
+
+            cmd.append("ad ");
             cmd.append("\"");
             cmd.append(p.getName().toString());
             cmd.append("\"");


### PR DESCRIPTION
- For example, `a`, `ad` are both valid command words for add command.
- However, critical commands like `exit` and `clear` require the user to type full command word for it to be valid.
- Full testcases are added.
